### PR TITLE
Update for new Flutter version API

### DIFF
--- a/lib/src/redux_component/page.dart
+++ b/lib/src/redux_component/page.dart
@@ -205,7 +205,7 @@ class PageProvider extends InheritedWidget {
 
   static PageProvider tryOf(BuildContext context) {
     final PageProvider provider =
-        context.inheritFromWidgetOfExactType(PageProvider);
+        context.dependOnInheritedWidgetOfExactType<PageProvider>();
     return provider;
   }
 


### PR DESCRIPTION
This feature was deprecated after v1.12.1. Use dependOnInheritedWidgetOfExactType instead.